### PR TITLE
Add support for returning pre and postorder visit counts

### DIFF
--- a/resource/hlapi/bindings/c++/reapi_cli.hpp
+++ b/resource/hlapi/bindings/c++/reapi_cli.hpp
@@ -48,7 +48,9 @@ public:
                                bool orelse_reserve,
                                const std::string &jobspec,
                                uint64_t &jobid, bool &reserved,
-                               std::string &R, int64_t &at, double &ov);
+                               std::string &R, int64_t &at, 
+                               unsigned int &preorder_count, 
+                               unsigned int &postorder_count, double &ov);
     static int match_allocate_multi (void *h, bool orelse_reserve,
                                      const char *jobs,
                                      queue_adapter_base_t *adapter);

--- a/resource/hlapi/bindings/c/reapi_cli.cpp
+++ b/resource/hlapi/bindings/c/reapi_cli.cpp
@@ -83,7 +83,10 @@ extern "C" char* reapi_cli_get_node (reapi_cli_ctx_t *ctx) {
 extern "C" int reapi_cli_match_allocate (reapi_cli_ctx_t *ctx,
                    bool orelse_reserve, const char *jobspec,
                    uint64_t *jobid, bool *reserved,
-                   char **R, int64_t *at, double *ov)
+                   char **R, int64_t *at, 
+                   unsigned int *preorder_count,
+                   unsigned int *postorder_count,
+                   double *ov)
 {
     int rc = -1;
     std::string R_buf = "";
@@ -95,7 +98,9 @@ extern "C" int reapi_cli_match_allocate (reapi_cli_ctx_t *ctx,
     }
     if ((rc = reapi_cli_t::match_allocate (ctx->rctx, orelse_reserve, jobspec,
                                            *jobid, *reserved,
-                                           R_buf, *at, *ov)) < 0) {
+                                           R_buf, *at, 
+                                           *preorder_count,
+                                           *postorder_count, *ov)) < 0) {
         goto out;
     }
     if ( !(R_buf_c = strdup (R_buf.c_str ()))) {

--- a/resource/hlapi/bindings/c/reapi_cli.h
+++ b/resource/hlapi/bindings/c/reapi_cli.h
@@ -72,6 +72,10 @@ char* reapi_cli_get_node (reapi_cli_ctx_t *ctx);
  *                   allocated or reserved.
  *  \param at        If allocated, 0 is returned; if reserved, actual time
  *                   at which the job is reserved.
+ *  \param preorder_count Unsigned int into which to return the traverser 
+ *                   preorder count.
+ *  \param postorder_count Unsigned int into which to return the traverser 
+ *                   postorder count.
  *  \param ov        Double into which to return performance overhead
  *                   in terms of elapse time needed to complete
  *                   the match operation.
@@ -80,7 +84,10 @@ char* reapi_cli_get_node (reapi_cli_ctx_t *ctx);
 int reapi_cli_match_allocate (reapi_cli_ctx_t *ctx, bool orelse_reserve,
                               const char *jobspec, uint64_t *jobid,
                               bool *reserved,
-                              char **R, int64_t *at, double *ov);
+                              char **R, int64_t *at, 
+                              unsigned int *preorder_count,
+                              unsigned int *postorder_count,
+                              double *ov);
 
 /*! Update the resource state with R.
  *

--- a/resource/hlapi/bindings/go/src/fluxcli/reapi_cli.go
+++ b/resource/hlapi/bindings/go/src/fluxcli/reapi_cli.go
@@ -64,7 +64,9 @@ int reapi_module_match_allocate (reapi_module_ctx_t *ctx, bool orelse_reserve,
 */
 
 func ReapiCliMatchAllocate(ctx *ReapiCtx, orelse_reserve bool,
-	jobspec string) (reserved bool, allocated string, at int64, overhead float64, jobid uint64, err int) {
+	jobspec string) (reserved bool, allocated string, at int64,
+	preorder_count uint32, postorder_count uint32, overhead float64,
+	jobid uint64, err int) {
 	var r = C.CString("teststring")
 
 	err = (int)(C.reapi_cli_match_allocate((*C.struct_reapi_cli_ctx)(ctx),
@@ -74,9 +76,12 @@ func ReapiCliMatchAllocate(ctx *ReapiCtx, orelse_reserve bool,
 		(*C.bool)(&reserved),
 		&r,
 		(*C.long)(&at),
+		(*C.uint)(&preorder_count),
+		(*C.uint)(&postorder_count),
 		(*C.double)(&overhead)))
 	allocated = C.GoString(r)
-	return reserved, allocated, at, overhead, jobid, err
+	return reserved, allocated, at, preorder_count, postorder_count, overhead,
+		jobid, err
 
 }
 

--- a/resource/hlapi/bindings/go/src/main/main.go
+++ b/resource/hlapi/bindings/go/src/main/main.go
@@ -32,18 +32,18 @@ func main() {
 	}
 	fmt.Printf("Jobspec:\n %s\n", jobspec)
 
-	reserved, allocated, at, overhead, jobid, fluxerr := ReapiCliMatchAllocate(ctx, *reserve, string(jobspec))
+	reserved, allocated, at, pre, post, overhead, jobid, fluxerr := ReapiCliMatchAllocate(ctx, *reserve, string(jobspec))
 	if fluxerr != 0 {
 		fmt.Println("Error in ReapiCliMatchAllocate")
 		return
 	}
-	printOutput(reserved, allocated, at, overhead, jobid, fluxerr)
-	reserved, allocated, at, overhead, jobid, fluxerr = ReapiCliMatchAllocate(ctx, *reserve, string(jobspec))
+	printOutput(reserved, allocated, at, pre, post, overhead, jobid, fluxerr)
+	reserved, allocated, at, pre, post, overhead, jobid, fluxerr = ReapiCliMatchAllocate(ctx, *reserve, string(jobspec))
 	if fluxerr != 0 {
 		fmt.Println("Error in ReapiCliMatchAllocate")
 		return
 	}
-	printOutput(reserved, allocated, at, overhead, jobid, fluxerr)
+	printOutput(reserved, allocated, at, pre, post, overhead, jobid, fluxerr)
 	fluxerr = ReapiCliCancel(ctx, 1, false)
 	if fluxerr != 0 {
 		fmt.Println("Error in ReapiCliCancel")
@@ -67,7 +67,7 @@ func main() {
 
 }
 
-func printOutput(reserved bool, allocated string, at int64, overhead float64, jobid uint64, fluxerr int) {
+func printOutput(reserved bool, allocated string, at int64, pre uint32, post uint32, overhead float64, jobid uint64, fluxerr int) {
 	fmt.Println("\n\t----Match Allocate output---")
-	fmt.Printf("jobid: %d\nreserved: %t\nallocated: %s\nat: %d\noverhead: %f\nerror: %d\n", jobid, reserved, allocated, at, overhead, fluxerr)
+	fmt.Printf("jobid: %d\nreserved: %t\nallocated: %s\nat: %d\npreorder visit count: %d\npostorder visit count: %d\noverhead: %f\nerror: %d\n", jobid, reserved, allocated, at, pre, post, overhead, fluxerr)
 }


### PR DESCRIPTION
This PR adds support for returning the pre and postorder visit counts of the Fluxion traverser.  Note that `ReapiCliMatchAllocate` calls in https://github.com/cmisale/scheduler-plugins/tree/kubeflux will need to be updated with the additional returns.